### PR TITLE
Switch from yaml.load to yaml.safe_load

### DIFF
--- a/easy2fa/storage.py
+++ b/easy2fa/storage.py
@@ -101,7 +101,7 @@ class AccountStorage(object):
 
     def _load(self):
         with open(self.filename, 'r') as fd:
-            self.shelf = yaml.load(fd)
+            self.shelf = yaml.safe_load(fd)
         if self.shelf is None:
             self.shelf = {'accounts': {}}
         assert(isinstance(self.shelf, dict))


### PR DESCRIPTION
In accordance with the PyYAML v6 deprecation of yaml.load() in favor of yaml.safe_load() [1], adopt the usage of safe_load. See issue #2

[1] https://github.com/yaml/pyyaml/wiki/PyYAML-yaml.load(input)-Deprecation